### PR TITLE
Simplify intro and refine stats visuals

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,36 +9,6 @@
 <body class="black">
   <div id="logo-screen" class="center">
     <img src="logo.png" alt="Logo" id="logo" />
-    <p id="logo-text" class="hidden">Construa a si mesmo</p>
-  </div>
-
-  <div id="intro-matters" class="hidden center intro-screen">
-    <p id="intro-matters-text"></p>
-  </div>
-
-  <div id="intro-level" class="hidden center intro-screen">
-    <p id="intro-level-text"></p>
-  </div>
-
-  <div id="question-screen" class="hidden center">
-    <h1 id="question-title"></h1>
-    <img id="aspect-image" class="aspect-image" alt="Aspecto" />
-    <div class="progress-container">
-      <div id="progress-bar"></div>
-    </div>
-    <div id="slider-feedback" class="slider-feedback"></div>
-    <div class="slider-container">
-      <input type="range" min="0" max="100" value="50" id="slider" />
-    </div>
-    <button id="next-btn">Próximo</button>
-  </div>
-
-  <div id="name-screen" class="hidden center">
-    <h1>Assuma a Presidência</h1>
-    <p id="oath-text"></p>
-    <input type="text" id="username" placeholder="Seu nome" />
-    <label class="agree"><input type="checkbox" id="agree" /> Concordo</label>
-    <button id="start-btn" disabled>Continuar</button>
   </div>
 
   <header id="main-header" class="hidden">

--- a/js/stats.js
+++ b/js/stats.js
@@ -36,7 +36,7 @@ function buildStats() {
   circle.setAttribute('cx', '125');
   circle.setAttribute('cy', '125');
   circle.setAttribute('r', String(radius));
-  circle.setAttribute('stroke-width', '20');
+  circle.setAttribute('stroke-width', '15');
   circle.setAttribute('fill', 'none');
   circle.setAttribute('stroke-dasharray', String(circumference));
   svg.appendChild(circle);

--- a/styles.css
+++ b/styles.css
@@ -483,24 +483,33 @@ li:hover { transform: scale(1.02); }
 
 .stats-display {
   position: relative;
-  width: 250px;
-  height: 250px;
+  width: 280px;
+  height: 280px;
+  margin: 20px;
 }
 
 .stats-aspect-image {
-  width: 250px;
-  height: 250px;
+  width: 80%;
+  height: 80%;
   display: block;
+  margin: 10%;
 }
 
 .stats-circle {
   position: absolute;
   top: 0;
   left: 0;
-  width: 250px;
-  height: 250px;
+  width: 100%;
+  height: 100%;
   pointer-events: none;
   transform: rotate(-90deg);
+}
+
+@media (min-width: 768px) {
+  .stats-display {
+    width: 312px;
+    height: 312px;
+  }
 }
 
 .stats-name {


### PR DESCRIPTION
## Summary
- Show only the logo for three seconds on load and jump straight to the app
- Resize neon stats circle with desktop/mobile tweaks and wider margins
- Shrink aspect icon inside stats circle and reduce stroke width

## Testing
- `node --check js/main.js`
- `node --check js/stats.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68acfec80d508325aa5a0e9de7773250