### PR TITLE
Animações e barra de avaliação no menu de estatísticas

### DIFF
--- a/js/stats.js
+++ b/js/stats.js
@@ -4,11 +4,21 @@ let statsColors = {};
 let aspectsData = {};
 let currentIndex = 0;
 
+// Mapeia o nível para a cor correspondente
+function getColor(level) {
+  if (level <= 20) return '#ff0000';
+  if (level <= 30) return '#ffa500';
+  if (level <= 50) return '#ffff00';
+  if (level <= 65) return '#00ffff';
+  if (level <= 80) return '#00ff00';
+  return '#40e0d0';
+}
+
 export function initStats(keys, res, colors, aspects) {
-  aspectKeys = keys;
+  aspectKeys = ['logo', ...keys];
   responses = res;
   statsColors = colors;
-  aspectsData = aspects;
+  aspectsData = { ...aspects, logo: { image: 'logo.png' } };
   currentIndex = 0;
   buildStats();
 }
@@ -27,35 +37,92 @@ function buildStats() {
 
   const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
   svg.classList.add('stats-circle');
-  svg.setAttribute('width', '250');
-  svg.setAttribute('height', '250');
-  svg.setAttribute('viewBox', '0 0 250 250');
+  svg.setAttribute('width', '300');
+  svg.setAttribute('height', '300');
+  svg.setAttribute('viewBox', '0 0 300 300');
   const circle = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
-  const radius = 115;
+  const radius = 135;
   const circumference = 2 * Math.PI * radius;
-  circle.setAttribute('cx', '125');
-  circle.setAttribute('cy', '125');
+  circle.setAttribute('cx', '150');
+  circle.setAttribute('cy', '150');
   circle.setAttribute('r', String(radius));
-  circle.setAttribute('stroke-width', '15');
+  circle.setAttribute('stroke-width', '18');
   circle.setAttribute('fill', 'none');
   circle.setAttribute('stroke-dasharray', String(circumference));
-  svg.appendChild(circle);
+  const circuloAvaliacao = circle; // círculo de avaliação
+  svg.appendChild(circuloAvaliacao);
   display.appendChild(svg);
 
   const name = document.createElement('div');
   name.className = 'stats-name';
   container.appendChild(name);
 
+  const barraAvaliacao = document.createElement('input');
+  barraAvaliacao.type = 'range';
+  barraAvaliacao.className = 'barra-avaliacao';
+  barraAvaliacao.min = '0';
+  barraAvaliacao.max = '100';
+  container.appendChild(barraAvaliacao);
+
+  function setCircle(level) {
+    const color = getColor(level);
+    circuloAvaliacao.setAttribute('stroke', color);
+    circuloAvaliacao.style.filter = `drop-shadow(0 0 6px ${color}) drop-shadow(0 0 12px ${color})`;
+    circuloAvaliacao.setAttribute('stroke-dashoffset', String(circumference * (1 - level / 100)));
+  }
+
+  function updateBar(level) {
+    const color = getColor(level);
+    barraAvaliacao.style.setProperty('--barra-cor', color);
+    barraAvaliacao.style.background = `linear-gradient(to right, ${color} 0%, ${color} ${level}%, #333 ${level}%)`;
+  }
+
+  function animateCircle(target, duration, start = 0) {
+    const startTime = performance.now();
+    function frame(now) {
+      const progress = Math.min((now - startTime) / duration, 1);
+      const level = start + (target - start) * progress;
+      setCircle(level);
+      if (progress < 1) requestAnimationFrame(frame);
+    }
+    requestAnimationFrame(frame);
+  }
+
   function render() {
     const key = aspectKeys[currentIndex];
-    const level = responses[key]?.level || 0;
-    const color = statsColors[key]?.[1] || '#fff';
     img.src = aspectsData[key].image;
     img.alt = key;
-    name.textContent = `${key}: ${level}%`;
-    circle.setAttribute('stroke', color);
-    circle.style.filter = `drop-shadow(0 0 6px ${color}) drop-shadow(0 0 12px ${color})`;
-    circle.setAttribute('stroke-dashoffset', String(circumference * (1 - level / 100)));
+    name.textContent = key === 'logo' ? '' : key;
+
+    barraAvaliacao.oninput = null;
+    barraAvaliacao.onchange = null;
+
+    if (key === 'logo') {
+      barraAvaliacao.style.display = 'none';
+      animateCircle(100, 1000, 0);
+    } else {
+      const storedLevel = responses[key]?.level;
+      if (storedLevel != null) {
+        barraAvaliacao.style.display = 'none';
+        setCircle(storedLevel);
+      } else {
+        barraAvaliacao.style.display = 'block';
+        barraAvaliacao.value = '50';
+        updateBar(50);
+        animateCircle(50, 1000, 0);
+        barraAvaliacao.oninput = () => {
+          const val = parseInt(barraAvaliacao.value, 10);
+          setCircle(val);
+          updateBar(val);
+        };
+        barraAvaliacao.onchange = () => {
+          const val = parseInt(barraAvaliacao.value, 10);
+          responses[key] = { ...(responses[key] || {}), level: val };
+          localStorage.setItem('responses', JSON.stringify(responses));
+          barraAvaliacao.style.display = 'none';
+        };
+      }
+    }
   }
 
   render();
@@ -70,6 +137,16 @@ function buildStats() {
       currentIndex = (currentIndex - 1 + aspectKeys.length) % aspectKeys.length;
       render();
     } else if (dx < -50) {
+      currentIndex = (currentIndex + 1) % aspectKeys.length;
+      render();
+    }
+  });
+
+  document.addEventListener('keydown', e => {
+    if (e.key === 'ArrowLeft') {
+      currentIndex = (currentIndex - 1 + aspectKeys.length) % aspectKeys.length;
+      render();
+    } else if (e.key === 'ArrowRight') {
       currentIndex = (currentIndex + 1) % aspectKeys.length;
       render();
     }

--- a/styles.css
+++ b/styles.css
@@ -125,7 +125,8 @@ body.black .menu-item img,
 body.black .menu-carousel img,
 body.black #header-logo,
 body.black .icone-central {
-  filter: drop-shadow(0 0 10px var(--neon-color));
+  /* Removido o brilho neon verde dos ícones do menu inicial */
+  filter: none;
 }
 
 body.black .progress-container {
@@ -481,12 +482,12 @@ li:hover { transform: scale(1.02); }
   touch-action: pan-y;
 }
 
-.stats-display {
-  position: relative;
-  width: 280px;
-  height: 280px;
-  margin: 20px;
-}
+  .stats-display {
+    position: relative;
+    width: 336px;
+    height: 336px;
+    margin: 20px;
+  }
 
 .stats-aspect-image {
   width: 80%;
@@ -505,20 +506,50 @@ li:hover { transform: scale(1.02); }
   transform: rotate(-90deg);
 }
 
-@media (min-width: 768px) {
-  .stats-display {
-    width: 312px;
-    height: 312px;
+  @media (min-width: 768px) {
+    .stats-display {
+      width: 374px;
+      height: 374px;
+    }
   }
-}
 
-.stats-name {
-  margin-top: 20px;
-  color: #ccc;
-  text-align: center;
-  font-family: 'Open Sans', sans-serif;
-  font-weight: 700;
-}
+  .stats-name {
+    margin-top: 5px;
+    color: #ccc;
+    text-align: center;
+    font-family: 'Open Sans', sans-serif;
+    font-weight: 700;
+  }
+
+  .barra-avaliacao {
+    width: 90%;
+    height: 20px;
+    margin: 20px auto 0;
+    background: #333;
+    border-radius: 10px;
+    outline: none;
+    appearance: none;
+  }
+
+  .barra-avaliacao::-webkit-slider-thumb {
+    appearance: none;
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    background: var(--barra-cor, #fff);
+    box-shadow: 0 0 10px var(--barra-cor, #fff), 0 0 20px var(--barra-cor, #fff);
+    cursor: pointer;
+  }
+
+  .barra-avaliacao::-moz-range-thumb {
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    background: var(--barra-cor, #fff);
+    box-shadow: 0 0 10px var(--barra-cor, #fff), 0 0 20px var(--barra-cor, #fff);
+    cursor: pointer;
+    border: none;
+  }
 
 #task-modal {
   position: fixed;


### PR DESCRIPTION
## Summary
- Adiciona barra de avaliação com gradiente neon e ligação direta ao círculo de avaliação
- Amplia o círculo de avaliação em 20% e introduz animações para logo e aspectos
- Remove o brilho neon verde dos ícones do menu inicial

## Testing
- `npm test` *(falhou: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad080615e483258a786e9dffea4ac7