### PR TITLE
Expand stats display area

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -487,6 +487,7 @@ li:hover { transform: scale(1.02); }
     width: 336px;
     height: 336px;
     margin: 20px;
+    padding: 25px;
   }
 
 .stats-aspect-image {


### PR DESCRIPTION
## Summary
- increase spacing around stats display to add 50px padding while keeping SVG size

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad0c31287483259491c6ebb58b8702