### PR TITLE
Fix neon stats circle clipping

### DIFF
--- a/js/stats.js
+++ b/js/stats.js
@@ -40,6 +40,7 @@ function buildStats() {
   svg.setAttribute('width', '300');
   svg.setAttribute('height', '300');
   svg.setAttribute('viewBox', '0 0 300 300');
+  svg.setAttribute('overflow', 'visible');
   const circle = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
   const radius = 135;
   const circumference = 2 * Math.PI * radius;

--- a/styles.css
+++ b/styles.css
@@ -505,6 +505,7 @@ li:hover { transform: scale(1.02); }
   height: 100%;
   pointer-events: none;
   transform: rotate(-90deg);
+  overflow: visible;
 }
 
   @media (min-width: 768px) {


### PR DESCRIPTION
## Summary
- ensure stats circle SVG allows overflow
- prevent CSS from clipping glow

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ad1328a59483259ae9d7d42af9b2b8