### PR TITLE
Focus task list on current day and allow full status management

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,6 +40,10 @@
             <h2>Tarefas agendadas</h2>
             <div class="task-group" id="pending-list"></div>
           </div>
+          <div id="tasks-in-progress">
+            <h2>Em curso</h2>
+            <div class="task-group" id="in-progress-list"></div>
+          </div>
           <div id="tasks-completed">
             <h2>Concluídas</h2>
             <div class="task-group" id="completed-list"></div>
@@ -131,9 +135,13 @@
           <option value="Tarefa">Tarefa</option>
           <option value="Agenda">Agenda</option>
         </select>
+        <select id="task-status">
+          <option value="pending">Agendada</option>
+          <option value="completed">Concluída</option>
+        </select>
         <button id="save-task">Salvar</button>
       </div>
-      <button id="complete-task" class="hidden">Concluir</button>
+      <button id="delete-task" class="hidden decline-btn">Excluir</button>
       <button id="cancel-task">Cancelar</button>
     </div>
   </div>

--- a/styles.css
+++ b/styles.css
@@ -415,6 +415,11 @@ li:hover { transform: scale(1.02); }
   box-shadow: 0 0 10px #39ff14;
 }
 
+.task-item.in-progress {
+  background: linear-gradient(135deg, #000, #00008b);
+  box-shadow: 0 0 10px #00008b;
+}
+
 .task-item h3 {
   margin: 0 0 5px 0;
   font-size: 20px;


### PR DESCRIPTION
## Summary
- Show only today's tasks and track "Em curso" activities before they become overdue
- Allow creating past-dated actions that default to completed and provide status toggling
- Add delete option in action editor and dark blue styling for in-progress tasks

## Testing
- `node --check js/tasks.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf08c1530c832596a83ea0d174bad9