### PR TITLE
Center modals and add task duration input

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,6 +128,7 @@
         </select>
       </div>
       <div class="task-step hidden" id="task-step-3">
+        <input type="number" id="task-duration" min="0" placeholder="Duração (min)" />
         <select id="task-aspect"></select>
         <button id="save-task">Salvar</button>
       </div>

--- a/js/history.js
+++ b/js/history.js
@@ -44,7 +44,7 @@ export function initHistory(aspects) {
     else if (e.key === 'ArrowRight') changePeriod(1);
   });
   noteSave.addEventListener('click', saveNote);
-  noteClose.addEventListener('click', () => { noteModal.classList.add('hidden'); currentNoteKey = null; });
+  noteClose.addEventListener('click', () => { noteModal.classList.add('hidden'); noteModal.classList.remove('show'); currentNoteKey = null; });
   buildCalendar();
   setInterval(buildCalendar, 60000);
   window.buildCalendar = buildCalendar;
@@ -139,6 +139,7 @@ function openNote(key) {
     noteListDiv.appendChild(p);
   });
   noteText.value = '';
+  noteModal.classList.add('show');
   noteModal.classList.remove('hidden');
 }
 
@@ -151,6 +152,7 @@ function saveNote() {
   notes[currentNoteKey].push(txt.slice(0,2000));
   localStorage.setItem('notes', JSON.stringify(notes));
   noteModal.classList.add('hidden');
+  noteModal.classList.remove('show');
   currentNoteKey = null;
   buildCalendar();
 }

--- a/js/tasks.js
+++ b/js/tasks.js
@@ -17,6 +17,7 @@ const taskCustomInputs = document.querySelectorAll('#task-custom-week input');
 const taskTimeInput = document.getElementById('task-time');
 const taskAspectInput = document.getElementById('task-aspect');
 const taskNoTimeInput = document.getElementById('task-no-time');
+const taskDurationInput = document.getElementById('task-duration');
 const saveTaskBtn = document.getElementById('save-task');
 const cancelTaskBtn = document.getElementById('cancel-task');
 const deleteTaskBtn = document.getElementById('delete-task');
@@ -259,6 +260,7 @@ export function openTaskModal(index = null, prefill = null) {
   taskCustomWeekDiv.classList.add('hidden');
   taskTimeInput.value = now.toTimeString().slice(0,5);
   taskNoTimeInput.value = '';
+  taskDurationInput.value = '15';
   taskCustomInputs.forEach(i => (i.checked = false));
   if (index !== null) {
     const tasks = JSON.parse(localStorage.getItem('tasks') || '[]');
@@ -277,6 +279,7 @@ export function openTaskModal(index = null, prefill = null) {
     }
     taskAspectInput.value = t.aspect;
     taskNoTimeInput.value = t.noTime || '';
+    taskDurationInput.value = t.duration || 15;
     document.querySelector('#task-modal h2').textContent = 'Editar tarefa';
     deleteTaskBtn.classList.remove('hidden');
   } else {
@@ -292,9 +295,11 @@ export function openTaskModal(index = null, prefill = null) {
         taskDateInput.value = d.toISOString().slice(0,10);
         taskTimeInput.value = d.toTimeString().slice(0,5);
       }
+      taskDurationInput.value = prefill.duration || 15;
     } else {
       taskTitleInput.value = '';
       taskAspectInput.value = aspectKeys[0] || '';
+      taskDurationInput.value = '15';
     }
   }
   showTaskStep(1);
@@ -361,6 +366,7 @@ function saveTask() {
   const aspect = taskAspectInput.value;
   const noTime = taskNoTimeInput.value;
   const time = taskTimeInput.value;
+  const duration = parseInt(taskDurationInput.value) || 0;
   const dateOption = taskDateOption.value;
   const tasks = JSON.parse(localStorage.getItem('tasks') || '[]');
   if (!noTime) {
@@ -381,7 +387,7 @@ function saveTask() {
       title: title.slice(0, 27),
       aspect,
       type: 'Tarefa',
-      duration: 0,
+      duration,
       completed: false
     };
     if (dateOption === 'custom' && editingTaskIndex === null) {
@@ -393,7 +399,7 @@ function saveTask() {
         const d = new Date(datetime);
         const diff = (day - d.getDay() + 7) % 7;
         d.setDate(d.getDate() + diff);
-        const conflicts = findConflicts(d, 0, tasks);
+        const conflicts = findConflicts(d, duration, tasks);
         if (conflicts.length) {
           pendingTask = { ...baseTask, startTime: d.toISOString(), editIndex: null };
           conflictingIndices = conflicts.map(c => c.idx);
@@ -406,7 +412,7 @@ function saveTask() {
       }
     } else {
       if (editingTaskIndex !== null) {
-        const conflicts = findConflicts(datetime, 0, tasks, editingTaskIndex);
+        const conflicts = findConflicts(datetime, duration, tasks, editingTaskIndex);
         if (conflicts.length) {
           pendingTask = { ...baseTask, startTime: datetime.toISOString(), editIndex: editingTaskIndex };
           conflictingIndices = conflicts.map(c => c.idx);
@@ -416,7 +422,7 @@ function saveTask() {
         }
         tasks[editingTaskIndex] = { ...baseTask, startTime: datetime.toISOString() };
       } else {
-        const conflicts = findConflicts(datetime, 0, tasks);
+        const conflicts = findConflicts(datetime, duration, tasks);
         if (conflicts.length) {
           pendingTask = { ...baseTask, startTime: datetime.toISOString(), editIndex: null };
           conflictingIndices = conflicts.map(c => c.idx);
@@ -432,7 +438,7 @@ function saveTask() {
       title: title.slice(0, 27),
       aspect,
       type: 'Tarefa',
-      duration: 0,
+      duration,
       noTime,
       completed: false
     };

--- a/styles.css
+++ b/styles.css
@@ -575,6 +575,32 @@ li:hover { transform: scale(1.02); }
 }
 
 #law-modal,
+#note-modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0,0,0,0.7);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 1500;
+}
+
+#law-modal.show,
+#note-modal.show {
+  display: flex;
+}
+
+#law-modal .task-form,
+#note-modal .task-form {
+  width: 70%;
+  max-width: none;
+  max-height: 70%;
+  overflow-y: auto;
+}
+
 #mindset-modal,
 #law-action-modal,
 #conflict-modal {
@@ -590,7 +616,6 @@ li:hover { transform: scale(1.02); }
   z-index: 1500;
 }
 
-#law-modal.show,
 #mindset-modal.show,
 #law-action-modal.show,
 #conflict-modal.show {


### PR DESCRIPTION
## Summary
- Center note and law creation modals with 70% viewport coverage and dimmed background
- Add task duration input to third step of task creation and integrate with task logic
- Fix note modal show/hide handling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bfdf0065388325aef33e81bde95bf0