### PR TITLE
Add sound effects, data import/export, and theme-specific colors

### DIFF
--- a/js/laws.js
+++ b/js/laws.js
@@ -1,4 +1,4 @@
-import { applyCascade, hexToRgba } from './utils.js';
+import { applyCascade, hexToRgba, playSound } from './utils.js';
 
 let aspectKeys = [];
 let lawsData = [];
@@ -191,6 +191,7 @@ function saveLaw() {
   localStorage.setItem('customLaws', JSON.stringify(laws));
   closeLawModal();
   buildLaws();
+  playSound('newlaw');
 }
 
 function suggestLaw() {
@@ -200,6 +201,7 @@ function suggestLaw() {
   laws.push({ title: idea.title, aspect: idea.aspect, description: idea.description || '' });
   localStorage.setItem('customLaws', JSON.stringify(laws));
   buildLaws();
+  playSound('newlaw');
 }
 
 function openLawActionModal(index) {

--- a/js/tasks.js
+++ b/js/tasks.js
@@ -1,3 +1,5 @@
+import { playSound } from './utils.js';
+
 let aspectKeys = [];
 let tasksData = [];
 let editingTaskIndex = null;
@@ -160,6 +162,7 @@ function buildTasks() {
     const div = document.createElement('div');
     div.className = 'task-item';
     div.dataset.index = index;
+    div.setAttribute('data-no-click', 'true');
 
     const icon = document.createElement('img');
     icon.className = 'task-aspect-icon';
@@ -183,6 +186,7 @@ function buildTasks() {
       tasks[index].completed = true;
       localStorage.setItem('tasks', JSON.stringify(tasks));
       buildTasks();
+      playSound('taskcomplete');
     });
     let pressTimer;
     const start = () => {
@@ -324,6 +328,7 @@ function suggestTask() {
   localStorage.setItem('tasks', JSON.stringify(tasks));
   buildTasks();
   if (window.buildCalendar) window.buildCalendar();
+  playSound('newtask');
 }
 
 function closeTaskModal() {
@@ -445,9 +450,11 @@ function saveTask() {
     if (editingTaskIndex !== null) tasks[editingTaskIndex] = taskObj; else tasks.push(taskObj);
   }
   localStorage.setItem('tasks', JSON.stringify(tasks));
+  const isNew = editingTaskIndex === null;
   closeTaskModal();
   buildTasks();
   if (window.buildCalendar) window.buildCalendar();
+  if (isNew) playSound('newtask');
 }
 
 function deleteTask() {
@@ -475,6 +482,7 @@ function replaceAllConflicts() {
       tasks.push(pendingTask);
     }
   }
+  const addedNew = pendingTask && pendingTask.editIndex === null;
   localStorage.setItem('tasks', JSON.stringify(tasks));
   conflictModal.classList.add('hidden');
   conflictModal.classList.remove('show');
@@ -482,5 +490,6 @@ function replaceAllConflicts() {
   conflictingIndices = [];
   buildTasks();
   if (window.buildCalendar) window.buildCalendar();
+  if (addedNew) playSound('newtask');
 }
 

--- a/js/utils.js
+++ b/js/utils.js
@@ -13,3 +13,19 @@ export function hexToRgba(hex, alpha = 1) {
   const b = bigint & 255;
   return `rgba(${r}, ${g}, ${b}, ${alpha})`;
 }
+
+const soundMap = {
+  click: new Audio('sounds/click.wav'),
+  type: new Audio('sounds/type.mp3'),
+  taskcomplete: new Audio('sounds/taskcomplete.wav'),
+  newtask: new Audio('sounds/newtask.wav'),
+  newlaw: new Audio('sounds/newlaw.wav')
+};
+
+export function playSound(name) {
+  const sound = soundMap[name];
+  if (sound) {
+    const clone = sound.cloneNode();
+    clone.play();
+  }
+}


### PR DESCRIPTION
## Summary
- play click, typing, task completion, new task, and new law sounds
- support per-theme aspect colors and force black colors in minimalist mode
- add data export/import options for backup/restore

## Testing
- `node --version`
- `npm test` *(fails: no package.json)*
- `node --check js/main.js`


------
https://chatgpt.com/codex/tasks/task_e_68c22787e6c88325af16c7c1f376e027