### PR TITLE
feat: add task action management and stats

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,6 +40,7 @@
           <div id="tasks-hub">
             <button id="add-task-btn">▶️</button>
             <button id="suggest-task-btn">⭐</button>
+            <button id="archived-task-btn">📂</button>
           </div>
           <div id="tasks-pending">
             <h2>Tarefas agendadas</h2>
@@ -56,6 +57,10 @@
           <div id="tasks-overdue">
             <h2>Atrasadas</h2>
             <div class="task-group" id="overdue-list"></div>
+          </div>
+          <div id="tasks-paused">
+            <h2>Pausadas</h2>
+            <div class="task-group" id="paused-list"></div>
           </div>
           <div id="tasks-substituted">
             <h2>Substituídas</h2>
@@ -134,6 +139,24 @@
       </div>
       <button id="delete-task" class="hidden decline-btn">Excluir</button>
       <button id="cancel-task">Cancelar</button>
+    </div>
+  </div>
+
+  <div id="task-action-modal" class="hidden">
+    <div class="task-actions">
+      <button id="action-delay">Adiar</button>
+      <button id="action-desist">Desistir</button>
+      <button id="action-complete">Concluída</button>
+      <button id="action-pause">Pausar</button>
+      <button id="action-cancel">Cancelar</button>
+    </div>
+  </div>
+
+  <div id="archived-modal" class="hidden">
+    <div class="task-form">
+      <h2>Arquivadas</h2>
+      <div id="archived-list"></div>
+      <button id="close-archived">Fechar</button>
     </div>
   </div>
 

--- a/js/stats.js
+++ b/js/stats.js
@@ -182,10 +182,10 @@ function getPhrase(key, level) {
 }
 
 export function initStats(keys, res, colors, aspects) {
-  aspectKeys = ['logo', ...keys];
+  aspectKeys = keys;
   responses = res;
   statsColors = colors;
-  aspectsData = { ...aspects, logo: { image: 'logo.png' } };
+  aspectsData = aspects;
   currentIndex = 0;
   buildStats();
 }
@@ -193,6 +193,11 @@ export function initStats(keys, res, colors, aspects) {
 function buildStats() {
   const container = document.getElementById('stats-content');
   container.innerHTML = '';
+
+  const actionStats = document.createElement('div');
+  actionStats.id = 'actions-stats';
+  container.appendChild(actionStats);
+  updateActionStats();
 
   const display = document.createElement('div');
   display.className = 'stats-display';
@@ -241,17 +246,10 @@ function buildStats() {
     const key = aspectKeys[currentIndex];
     img.src = aspectsData[key].image;
     img.alt = key;
-    name.textContent = key === 'logo' ? '' : key;
+    name.textContent = key;
 
     barraAvaliacao.oninput = null;
     barraAvaliacao.onchange = null;
-
-    if (key === 'logo') {
-      barraAvaliacao.style.display = 'none';
-      barraResultado.style.display = 'none';
-      phraseEl.textContent = '';
-      return;
-    }
 
     const storedLevel = responses[key]?.level;
 
@@ -328,5 +326,22 @@ function buildStats() {
     }
   });
 }
+
+export function updateActionStats() {
+  const el = document.getElementById('actions-stats');
+  if (!el) return;
+  const tasks = JSON.parse(localStorage.getItem('tasks') || '[]');
+  const total = tasks.length;
+  const conclu = tasks.filter(t => t.completed).length;
+  const desist = tasks.filter(t => t.desisted).length;
+  const agend = tasks.filter(t => !t.completed && !t.desisted).length;
+  el.innerHTML = `<h2>Estatísticas das Ações</h2>
+    <p>Ações totais: ${total}</p>
+    <p>Concluídas: ${conclu}</p>
+    <p>Agendadas: ${agend}</p>
+    <p>Desistidas: ${desist}</p>`;
+}
+
+window.updateActionStats = updateActionStats;
 
 export function checkStatsPrompt() {}

--- a/styles.css
+++ b/styles.css
@@ -419,6 +419,16 @@ li:hover { transform: scale(1.02); }
   box-shadow: 0 0 10px #00008b;
 }
 
+.task-item.paused {
+  background: linear-gradient(135deg, #000, #555);
+  box-shadow: 0 0 10px #555;
+}
+
+.task-item.desisted {
+  background: linear-gradient(135deg, #000, #444);
+  box-shadow: 0 0 10px #444;
+}
+
 .task-item h3 {
   margin: 0 0 5px 0;
   font-size: 20px;
@@ -585,6 +595,47 @@ li:hover { transform: scale(1.02); }
 
 #task-modal.show {
   display: flex;
+}
+
+#task-action-modal,
+#archived-modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0,0,0,0.8);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 1500;
+}
+
+#task-action-modal.show,
+#archived-modal.show {
+  display: flex;
+}
+
+#task-action-modal .task-actions {
+  background: linear-gradient(135deg, #000000, #40e0d0);
+  color: #fff;
+  padding: 20px;
+  border-radius: 8px;
+  width: calc(100% - 60px);
+  max-width: 400px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  font-family: 'Open Sans', sans-serif;
+  font-weight: 700;
+}
+
+#task-action-modal .task-actions button {
+  padding: 8px;
+  border: none;
+  border-radius: 4px;
+  background: rgba(255,255,255,0.2);
+  color: #fff;
 }
 
 #law-modal,


### PR DESCRIPTION
## Summary
- allow double-click task actions (adiar, desistir, concluir, pausar)
- show archived tasks and paused section
- display task statistics on stats page and remove intro logo

## Testing
- `node --check js/tasks.js`
- `node --check js/stats.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c26d61ddc4832592c19e227659a6ad