### PR TITLE
Adiciona visualização detalhada antes da edição de tarefas

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,7 +94,15 @@
   </main>
 
   <div id="task-modal" class="hidden">
-    <div class="task-form">
+    <div id="task-view" class="task-form hidden">
+      <h2 id="task-view-title"></h2>
+      <p id="task-view-status"></p>
+      <p id="task-view-remaining" class="hidden"></p>
+      <button id="edit-task">Editar</button>
+      <button id="delete-task-view" class="decline-btn">Excluir</button>
+      <button id="cancel-task-view">Cancelar</button>
+    </div>
+    <div id="task-form" class="task-form">
       <h2>Nova tarefa</h2>
       <div class="task-step" id="task-step-1">
         <input type="text" id="task-title" placeholder="Tarefa" maxlength="27" />


### PR DESCRIPTION
## Sumário
- exibe detalhes da tarefa em modo somente leitura
- permite habilitar edição via botão dedicado
- ajusta cor do modal conforme status da tarefa

## Testes
- `npm test` *(falhou: package.json ausente)*

------
https://chatgpt.com/codex/tasks/task_e_68c2724fb664832591a8c19f89286503