### PR TITLE
Refine mobile interactions and stats display

### DIFF
--- a/js/stats.js
+++ b/js/stats.js
@@ -335,11 +335,24 @@ export function updateActionStats() {
   const conclu = tasks.filter(t => t.completed).length;
   const desist = tasks.filter(t => t.desisted).length;
   const agend = tasks.filter(t => !t.completed && !t.desisted).length;
+  const completedTasks = tasks.filter(t => t.completed && !t.desisted);
+  const totalMin = completedTasks.reduce((s, t) => s + (t.duration || 0), 0);
+  const todayStr = new Date().toDateString();
+  const todayMin = completedTasks
+    .filter(t => {
+      if (t.startTime) {
+        return new Date(t.startTime).toDateString() === todayStr;
+      }
+      return ['today', 'morning', 'afternoon', 'night', ''].includes(t.noTime);
+    })
+    .reduce((s, t) => s + (t.duration || 0), 0);
   el.innerHTML = `<h2>Estatísticas das Ações</h2>
     <p>Ações totais: ${total}</p>
     <p>Concluídas: ${conclu}</p>
     <p>Agendadas: ${agend}</p>
-    <p>Desistidas: ${desist}</p>`;
+    <p>Desistidas: ${desist}</p>
+    <p>Minutos totais concluídos: ${totalMin}</p>
+    <p>Minutos concluídos hoje: ${todayMin}</p>`;
 }
 
 window.updateActionStats = updateActionStats;

--- a/js/tasks.js
+++ b/js/tasks.js
@@ -131,6 +131,16 @@ export function initTasks(keys, data, aspects) {
       if (dx < -50) nextTaskStep();
       else if (dx > 50) prevTaskStep();
     });
+    const tasksContent = document.getElementById('tasks-content');
+    let swipeX = 0;
+    tasksContent.addEventListener('touchstart', e => {
+      swipeX = e.touches[0].clientX;
+    });
+    tasksContent.addEventListener('touchend', e => {
+      const dx = e.changedTouches[0].clientX - swipeX;
+      if (dx < -50) changeTasksDate(1);
+      else if (dx > 50) changeTasksDate(-1);
+    });
     const icon = document.querySelector('#tasks .icone-central');
     if (icon) {
       let lastTap = 0;
@@ -282,7 +292,10 @@ function changeTasksDate(delta) {
 }
 
 function updateTasksDateLabel() {
-  currentDateSpan.textContent = currentTasksDate.toLocaleDateString('pt-BR');
+  const options = { day: 'numeric', month: 'long', year: 'numeric' };
+  const parts = currentTasksDate.toLocaleDateString('pt-BR', options).split(' ');
+  const month = parts[2] ? parts[2].charAt(0).toUpperCase() + parts[2].slice(1) : '';
+  currentDateSpan.textContent = `${parts[0]} de ${month} de ${parts[4]}`;
 }
 
 export function openTaskModal(index = null, prefill = null) {

--- a/styles.css
+++ b/styles.css
@@ -145,6 +145,16 @@ body.black .task-form {
   text-shadow: 0 0 5px var(--neon-color);
 }
 
+body.whitecolor .law-box,
+body.whitecolor .mindset-box,
+body.minimalist .law-box,
+body.minimalist .mindset-box {
+  background: var(--button-bg);
+  color: var(--text-color);
+  box-shadow: none;
+  text-shadow: none;
+}
+
 .center {
   display: flex;
   flex-direction: column;
@@ -459,7 +469,8 @@ li:hover { transform: scale(1.02); }
   right: 20px;
   text-align: right;
   font-weight: 700;
-  font-size: 28px;
+  font-size: 17px;
+  color: #fff;
 }
 
 #task-desc {
@@ -910,6 +921,20 @@ li:hover { transform: scale(1.02); }
   .task-item h3 { font-size: 12px; }
   .task-item span { font-size: 14px; }
   .task-form { padding: 14px; max-width: 280px; }
+  #tasks-prev-day,
+  #tasks-next-day { display: none; }
+  #tasks-date-nav {
+    display: block;
+    text-align: center;
+    margin-bottom: 20px;
+  }
+  #tasks-current-date {
+    display: block;
+    font-weight: 700;
+  }
+  #tasks-content > *:not(#tasks-date-nav) {
+    transform: translateY(-100px);
+  }
 }
 
 @media (min-width: 601px) {


### PR DESCRIPTION
## Summary
- Enable date changes on mobile via swipe and hide arrow buttons
- Format task date label and reposition elements for smaller screens
- Make law and mindset boxes solid in light themes and shrink timer color
- Show total completed minutes overall and today in statistics

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c2774042d0832587b5b53b0bb8a2ef