### PR TITLE
feat: add mobile actions menu date

### DIFF
--- a/index.html
+++ b/index.html
@@ -143,6 +143,7 @@
   </div>
 
   <div id="task-action-modal" class="hidden">
+    <div id="actions-date">11 de setembro de 2025</div>
     <div class="task-actions">
       <button id="action-delay">Adiar</button>
       <button id="action-desist">Desistir</button>

--- a/styles.css
+++ b/styles.css
@@ -649,6 +649,25 @@ li:hover { transform: scale(1.02); }
   color: #fff;
 }
 
+#actions-date {
+  display: none;
+}
+
+@media (max-width: 600px) {
+  #task-action-modal {
+    flex-direction: column;
+  }
+
+  #actions-date {
+    display: block;
+    color: #fff;
+    margin-bottom: 100px;
+    text-align: center;
+    font-family: 'Open Sans', sans-serif;
+    font-weight: 700;
+  }
+}
+
 #law-modal,
 #note-modal {
   position: fixed;


### PR DESCRIPTION
## Summary
- show written date above task actions menu on mobile
- style date to appear 100px above menu

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c2797f84c48325950c5b0f91ec1cd3