### PR TITLE
Adiciona botões de ações e data no rodapé para mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,9 +38,9 @@
             <button id="tasks-next-day">▶️</button>
           </div>
           <div id="tasks-hub">
-            <button id="add-task-btn">▶️</button>
-            <button id="suggest-task-btn">⭐</button>
-            <button id="archived-task-btn">📂</button>
+            <button id="add-task-btn">▶️ Criar tarefa</button>
+            <button id="suggest-task-btn">⭐ Ver ideias</button>
+            <button id="archived-task-btn">📂 Arquivadas</button>
           </div>
           <div id="tasks-pending">
             <h2>Tarefas agendadas</h2>
@@ -233,6 +233,8 @@
       <button id="note-close">Fechar</button>
     </div>
   </div>
+
+  <footer id="footer-date"></footer>
 
   <script type="module" src="js/main.js"></script>
 </body>

--- a/js/main.js
+++ b/js/main.js
@@ -188,6 +188,15 @@ document.addEventListener('keydown', e => {
 
 const headerLogo = document.getElementById('header-logo');
 const menuCarousel = document.getElementById('menu-carousel');
+const footerDate = document.getElementById('footer-date');
+if (footerDate) {
+  const now = new Date();
+  footerDate.textContent = now.toLocaleDateString('pt-BR', {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric'
+  });
+}
 
 let savedTheme = localStorage.getItem('theme');
 if (savedTheme === 'turquoise') {

--- a/styles.css
+++ b/styles.css
@@ -102,6 +102,11 @@ body.black li {
   text-shadow: 0 0 5px var(--text-color);
 }
 
+footer {
+  text-align: center;
+  margin-top: 20px;
+}
+
 #tasks-date-nav {
   display: flex;
   justify-content: center;
@@ -953,8 +958,18 @@ li:hover { transform: scale(1.02); }
     display: block;
     font-weight: 700;
   }
-  #tasks-content > *:not(#tasks-date-nav) {
+  #tasks-content > *:not(#tasks-date-nav):not(#tasks-hub) {
     transform: translateY(-100px);
+  }
+  footer {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    background: var(--bg-color);
+  }
+  body {
+    padding-bottom: 40px;
   }
 }
 


### PR DESCRIPTION
## Summary
- Restaura botões Criar tarefa, Ver ideias e Arquivadas no menu de ações
- Adiciona rodapé com data atual e script para preenchimento
- Ajusta estilos móveis para mostrar o hub de ações e posicionar o rodapé

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c27cfdf27c832595edc38a7735c20e