### PR TITLE
Mostrar no rodapé a data das tarefas selecionadas

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -188,15 +188,6 @@ document.addEventListener('keydown', e => {
 
 const headerLogo = document.getElementById('header-logo');
 const menuCarousel = document.getElementById('menu-carousel');
-const footerDate = document.getElementById('footer-date');
-if (footerDate) {
-  const now = new Date();
-  footerDate.textContent = now.toLocaleDateString('pt-BR', {
-    day: 'numeric',
-    month: 'long',
-    year: 'numeric'
-  });
-}
 
 let savedTheme = localStorage.getItem('theme');
 if (savedTheme === 'turquoise') {

--- a/js/tasks.js
+++ b/js/tasks.js
@@ -295,7 +295,10 @@ function updateTasksDateLabel() {
   const options = { day: 'numeric', month: 'long', year: 'numeric' };
   const parts = currentTasksDate.toLocaleDateString('pt-BR', options).split(' ');
   const month = parts[2] ? parts[2].charAt(0).toUpperCase() + parts[2].slice(1) : '';
-  currentDateSpan.textContent = `${parts[0]} de ${month} de ${parts[4]}`;
+  const dateStr = `${parts[0]} de ${month} de ${parts[4]}`;
+  currentDateSpan.textContent = dateStr;
+  const footer = document.getElementById('footer-date');
+  if (footer) footer.innerHTML = `<strong>${dateStr}</strong>`;
 }
 
 export function openTaskModal(index = null, prefill = null) {

--- a/styles.css
+++ b/styles.css
@@ -107,6 +107,10 @@ footer {
   margin-top: 20px;
 }
 
+#footer-date {
+  font-weight: 700;
+}
+
 #tasks-date-nav {
   display: flex;
   justify-content: center;


### PR DESCRIPTION
## Resumo
- Sincroniza o rodapé com a data exibida nas tarefas, atualizando ao alternar dias
- Remove a inicialização fixa da data no `main.js`
- Aplica estilo em negrito ao texto do rodapé

## Testes
- `npm test` *(falha: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c27f265ad083258477d66679a03826