### PR TITLE
Remove duplicate action date in mobile view

### DIFF
--- a/index.html
+++ b/index.html
@@ -143,7 +143,6 @@
   </div>
 
   <div id="task-action-modal" class="hidden">
-    <div id="actions-date">11 de setembro de 2025</div>
     <div class="task-actions">
       <button id="action-delay">Adiar</button>
       <button id="action-desist">Desistir</button>

--- a/styles.css
+++ b/styles.css
@@ -658,24 +658,9 @@ li:hover { transform: scale(1.02); }
   color: #fff;
 }
 
-#actions-date {
-  display: none;
-}
-
 @media (max-width: 600px) {
   #task-action-modal {
     flex-direction: column;
-  }
-
-  #actions-date {
-    display: block;
-    color: #fff;
-    margin-bottom: 100px;
-    text-align: center;
-    font-family: 'Open Sans', sans-serif;
-    font-weight: 700;
-    position: relative;
-    top: -100px;
   }
 }
 


### PR DESCRIPTION
## Summary
- Remove duplicate date text from action menu on mobile
- Clean up related CSS

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c2807a2f58832596784b9d85baf68c