### PR TITLE
Remove task date displays

### DIFF
--- a/js/tasks.js
+++ b/js/tasks.js
@@ -292,10 +292,6 @@ function changeTasksDate(delta) {
 }
 
 function updateTasksDateLabel() {
-  const options = { day: 'numeric', month: 'long', year: 'numeric' };
-  const parts = currentTasksDate.toLocaleDateString('pt-BR', options).split(' ');
-  const month = parts[2] ? parts[2].charAt(0).toUpperCase() + parts[2].slice(1) : '';
-  const dateStr = `${parts[0]} de ${month} de ${parts[4]}`;
   const dateNav = document.getElementById('tasks-date-nav');
   if (dateNav && currentDateSpan && currentDateSpan.parentElement !== dateNav) {
     if (nextDayBtn && dateNav.contains(nextDayBtn)) dateNav.insertBefore(currentDateSpan, nextDayBtn);
@@ -303,9 +299,9 @@ function updateTasksDateLabel() {
   }
   const pendingHeader = document.querySelector('#tasks-pending h2');
   if (pendingHeader) pendingHeader.textContent = 'Tarefas agendadas';
-  currentDateSpan.textContent = dateStr;
+  if (currentDateSpan) currentDateSpan.textContent = '';
   const footer = document.getElementById('footer-date');
-  if (footer) footer.innerHTML = `<strong>${dateStr}</strong>`;
+  if (footer) footer.textContent = '';
 }
 
 export function openTaskModal(index = null, prefill = null) {

--- a/styles.css
+++ b/styles.css
@@ -109,6 +109,11 @@ footer {
 
 #footer-date {
   font-weight: 700;
+  display: none;
+}
+
+#tasks-current-date {
+  display: none;
 }
 
 #tasks-date-nav {
@@ -944,8 +949,7 @@ li:hover { transform: scale(1.02); }
     margin-bottom: 20px;
   }
   #tasks-current-date {
-    display: block;
-    font-weight: 700;
+    display: none;
   }
   #tasks-content > *:not(#tasks-date-nav):not(#tasks-hub) {
     transform: translateY(-100px);


### PR DESCRIPTION
## Summary
- hide the current date indicator from the Ações menu navigation and footer
- update the tasks date refresh routine so no date text is injected into the DOM

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68c90f9f0d788325923bf1513cbd61e2