### PR TITLE
Atualizar rodapé de tarefas e menu móvel minimalista

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,9 +38,9 @@
             <button id="tasks-next-day">▶️</button>
           </div>
           <div id="tasks-hub">
-            <button id="add-task-btn">▶️ Criar tarefa</button>
-            <button id="suggest-task-btn">⭐ Ver ideias</button>
-            <button id="archived-task-btn">📂 Arquivadas</button>
+            <button id="add-task-btn" aria-label="Criar tarefa" title="Criar tarefa">▶️</button>
+            <button id="suggest-task-btn" aria-label="Ver ideias" title="Ver ideias">⭐</button>
+            <button id="archived-task-btn" aria-label="Tarefas arquivadas" title="Tarefas arquivadas">📂</button>
           </div>
           <div id="tasks-pending">
             <h2>Tarefas agendadas</h2>

--- a/js/main.js
+++ b/js/main.js
@@ -286,7 +286,11 @@ function initApp() {
   document.getElementById('main-header').classList.remove('hidden');
   document.getElementById('main-content').classList.remove('hidden');
   if (window.innerWidth <= 600) {
-    initCarousel();
+    if (savedTheme === 'minimalist') {
+      showPage('menu');
+    } else {
+      initCarousel();
+    }
   }
 }
 

--- a/js/tasks.js
+++ b/js/tasks.js
@@ -46,6 +46,31 @@ const nextDayBtn = document.getElementById('tasks-next-day');
 const currentDateSpan = document.getElementById('tasks-current-date');
 let currentTasksDate = new Date();
 
+const WEEKDAY_NAMES = [
+  'Domingo',
+  'Segunda-feira',
+  'Terça-feira',
+  'Quarta-feira',
+  'Quinta-feira',
+  'Sexta-feira',
+  'Sábado'
+];
+
+function getFutureWeekdayName(offset) {
+  const date = new Date();
+  date.setDate(date.getDate() + offset);
+  return WEEKDAY_NAMES[date.getDay()];
+}
+
+function updateWeekdayOptionLabels() {
+  const offsets = { weekday2: 2, weekday3: 3, weekday4: 4 };
+  Array.from(taskDateOption.options).forEach(opt => {
+    if (offsets[opt.value] !== undefined) {
+      opt.textContent = getFutureWeekdayName(offsets[opt.value]);
+    }
+  });
+}
+
 function showTaskStep(step) {
   currentTaskStep = step;
   step1Div.classList.add('hidden');
@@ -83,6 +108,7 @@ export function initTasks(keys, data, aspects) {
   aspectKeys = keys;
   tasksData = data;
   aspectsMap = aspects;
+  updateWeekdayOptionLabels();
   addTaskBtn.addEventListener('click', () => openTaskModal());
   suggestTaskBtn.addEventListener('click', suggestTask);
   archivedBtn.addEventListener('click', openArchivedModal);
@@ -280,9 +306,6 @@ function buildTasks() {
       pending.appendChild(div);
     }
   });
-  if (!pending.children.length && !inProgress.children.length && !completed.children.length && !overdue.children.length && !substituted.children.length && !paused.children.length) {
-    pending.textContent = 'Sem tarefas para hoje';
-  }
 }
 
 function changeTasksDate(delta) {
@@ -305,6 +328,7 @@ function updateTasksDateLabel() {
 }
 
 export function openTaskModal(index = null, prefill = null) {
+  updateWeekdayOptionLabels();
   editingTaskIndex = index;
   taskAspectInput.innerHTML = '';
   aspectKeys.forEach(k => {

--- a/styles.css
+++ b/styles.css
@@ -495,8 +495,49 @@ li:hover { transform: scale(1.02); }
   margin: 5px 0;
 }
 
+#tasks {
+  padding-bottom: 140px;
+}
+
 #tasks-hub {
-  margin-bottom: 20px;
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  gap: 24px;
+  padding: 14px 32px;
+  background: var(--bg-color);
+  box-shadow: 0 -4px 18px rgba(0, 0, 0, 0.35);
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  z-index: 1000;
+}
+
+body.whitecolor #tasks-hub,
+body.minimalist #tasks-hub {
+  border-top: 1px solid rgba(0, 0, 0, 0.08);
+  box-shadow: 0 -4px 18px rgba(0, 0, 0, 0.12);
+}
+
+#tasks-hub button {
+  width: 56px;
+  height: 56px;
+  padding: 0;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 28px;
+  color: var(--text-color);
+}
+
+#tasks-hub button:hover {
+  transform: translateY(-3px);
+}
+
+#tasks-hub button:active {
+  transform: scale(0.95);
 }
 
 .task-group {
@@ -936,6 +977,24 @@ li:hover { transform: scale(1.02); }
   .menu-grid { display: none; }
   .menu-carousel { display: flex; }
   #menu { display: none; }
+  body.minimalist .menu-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 24px;
+    justify-items: center;
+    width: 100%;
+    padding: 20px 24px 100px;
+  }
+  body.minimalist .menu-item img {
+    width: 120px;
+    height: 120px;
+  }
+  body.minimalist #menu.active {
+    display: block;
+  }
+  body.minimalist .menu-carousel {
+    display: none;
+  }
   .page { padding: 90px 30px 15px; }
   .page > h1 { display: none; }
   .task-item h3 { font-size: 12px; }
@@ -954,15 +1013,17 @@ li:hover { transform: scale(1.02); }
   #tasks-content > *:not(#tasks-date-nav):not(#tasks-hub) {
     transform: translateY(-100px);
   }
-  footer {
-    position: fixed;
-    bottom: 0;
-    left: 0;
-    width: 100%;
-    background: var(--bg-color);
+  #tasks-hub {
+    padding: 12px 20px;
+    gap: 18px;
   }
-  body {
-    padding-bottom: 40px;
+  #tasks-hub button {
+    width: 48px;
+    height: 48px;
+    font-size: 24px;
+  }
+  #tasks {
+    padding-bottom: 120px;
   }
 }
 


### PR DESCRIPTION
## Summary
- mover os atalhos de tarefas para um rodapé fixo apenas com ícones
- mostrar os nomes reais dos dias nos atalhos de data e remover o aviso de falta de tarefas
- ajustar o tema minimalista em telas móveis para abrir na grade de seis ícones sem o carrossel

## Testing
- no tests were run (not required)

------
https://chatgpt.com/codex/tasks/task_e_68caf88e7e0c8325b73099f7d0a8ee9f